### PR TITLE
rough fix

### DIFF
--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidation.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidation.java
@@ -71,8 +71,8 @@ public class OauthBearerValidation implements FilterFactory<OauthBearerValidatio
                         : SaslConfigs.DEFAULT_SASL_OAUTHBEARER_SCOPE_CLAIM_NAME,
                 config.subClaimName() != null && !config.subClaimName().trim().isEmpty() ? config.subClaimName() : SaslConfigs.DEFAULT_SASL_OAUTHBEARER_SUB_CLAIM_NAME,
                 config.authenticateBackOffMaxMs() != null && config.authenticateBackOffMaxMs() >= 0L ? config.authenticateBackOffMaxMs() : 60000L,
-                config.authenticateCacheMaxSize() != null && config.authenticateCacheMaxSize() > 0L ? config.authenticateCacheMaxSize()
-                        : 1000L);
+                config.authenticateCacheMaxSize() != null && config.authenticateCacheMaxSize() > 0L ? config.authenticateCacheMaxSize() : 1000L,
+                config.expectedAudience() != null && !config.expectedAudience().isEmpty() ? config.expectedAudience() : null);
         oauthHandler.configure(
                 createSaslConfigMap(configWithDefaults),
                 OAUTHBEARER_MECHANISM,
@@ -105,7 +105,8 @@ public class OauthBearerValidation implements FilterFactory<OauthBearerValidatio
                          @JsonProperty String scopeClaimName,
                          @JsonProperty String subClaimName,
                          @JsonProperty Long authenticateBackOffMaxMs,
-                         @JsonProperty Long authenticateCacheMaxSize) {}
+                         @JsonProperty Long authenticateCacheMaxSize,
+                         @JsonProperty List<String> expectedAudience) {}
 
     private Map<String, ?> createSaslConfigMap(Config config) {
         return Map.of(
@@ -114,7 +115,8 @@ public class OauthBearerValidation implements FilterFactory<OauthBearerValidatio
                 SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS, config.jwksEndpointRetryBackoffMs(),
                 SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS, config.jwksEndpointRetryBackoffMaxMs(),
                 SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME, config.scopeClaimName(),
-                SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME, config.subClaimName());
+                SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME, config.subClaimName(),
+                SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE, config.expectedAudience());
     }
 
     private List<AppConfigurationEntry> createDefaultJaasConfig() {

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationFilter.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationFilter.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.proxy.filter.oauthbearer;
 
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
@@ -168,7 +169,11 @@ public class OauthBearerValidationFilter
 
     private byte[] doAuthenticate(byte[] authBytes) throws SaslException {
         try {
-            return this.saslServer.evaluateResponse(authBytes);
+            byte[] bytes = this.saslServer.evaluateResponse(authBytes);
+            if (!this.saslServer.isComplete()) {
+                throw new SaslAuthenticationException("SASL failed : " + new String(bytes, StandardCharsets.UTF_8));
+            }
+            return bytes;
         }
         finally {
             this.saslServer.dispose();


### PR DESCRIPTION
Verify that the SASL server has actually completed the SASL negotiation properly, otherwise treats as a auth-failure.

Add config to express `sasl.oauthbearer.expected.audience` for use-cases where it is required.

No junit tests or docs added.
