### PR TITLE
Couple of improvements to renovate config.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,33 @@
+{
+  "baseBranches": ["main"],
+  "rebaseWhen": "conflicted",
+  "labels": ["dependencies"],
+  "automergeStrategy": "merge-commit",
+  "ignoreTests": true,
+  "extends": [
+    "config:recommended"
+  ],
+  "enabledManagers": [
+    "custom.regex"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultTestKmsFacade.java"],
+      "matchStrings": [
+        "DockerImageName\\.parse\\(\"hashicorp/vault:(?<currentValue>\\d+\\.\\d+)\"\\)"
+      ],
+      "depNameTemplate": "hashicorp/vault",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["kroxylicious/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java"],
+      "matchStrings": [
+        "kroxylicious/kcat:(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "kroxylicious/kcat",
+      "datasourceTemplate": "docker"
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,10 +2,12 @@
   "baseBranches": ["main"],
   "rebaseWhen": "conflicted",
   "labels": ["dependencies"],
+  "ignorePaths": [".github/renovate.json"],
   "automergeStrategy": "merge-commit",
   "ignoreTests": true,
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":gitSignOff"
   ],
   "enabledManagers": [
     "custom.regex"
@@ -13,20 +15,47 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultTestKmsFacade.java"],
-      "matchStrings": [
-        "DockerImageName\\.parse\\(\"hashicorp/vault:(?<currentValue>\\d+\\.\\d+)\"\\)"
+      "fileMatch": [
+        "kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultTestKmsFacade.java",
+        "performance-tests/docker-compose.yaml"
       ],
-      "depNameTemplate": "hashicorp/vault",
+      "matchStrings": [
+        "DockerImageName\\.parse\\(\"(?<depName>hashicorp/vault):(?<currentValue>\\d+\\.\\d+)\"\\)",
+        "image:.*(?<depName>hashicorp/vault):(?<currentValue>\\d+\\.\\d+)"
+      ],
       "datasourceTemplate": "docker"
     },
     {
       "customType": "regex",
-      "fileMatch": ["kroxylicious/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java"],
+      "fileMatch": ["kroxylicious-kms-provider-aws-kms-test-support/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTestKmsFacade.java"],
       "matchStrings": [
-        "kroxylicious/kcat:(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+        "DockerImageName\\.parse\\(\"(?<depName>localstack/localstack):(?<currentValue>\\d+\\.\\d+)\"\\)"
       ],
-      "depNameTemplate": "kroxylicious/kcat",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationIT.java"],
+      "matchStrings": [
+        "DockerImageName\\.parse\\(\"(?<depName>ghcr.io/navikt/mock-oauth2-server):(?<currentValue>\\d+\\.\\d+.\\d+)\"\\)"
+      ],
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/validation/JsonSchemaRecordValidationIT.java"],
+      "matchStrings": [
+        "DockerImageName\\.parse\\(\"(?<depName>quay.io/apicurio/apicurio-registry-mem):(?<currentValue>\\d+\\.\\d+\\.\\d+\\.Final)"
+      ],
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java"],
+      "matchStrings": [
+        "(?<depName>quay.io/kroxylicious/kcat):(?<currentValue>\\d+\\.\\d+\\.\\d+)",
+        "(?<depName>quay.io/kroxylicious/kaf):(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
       "datasourceTemplate": "docker"
     }
   ]

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,22 @@
+name: Renovate
+on:
+  schedule:
+    - cron: '0/30 * * * *'
+  workflow_dispatch:
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      - name: Renovate
+        uses: renovatebot/github-action@v41.0.7
+        with:
+          configurationFile: .github/renovate.json
+          token: ${{ secrets.KROXYLICIOUS_GITHUB_READWRITE_TOKEN }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_ONBOARDING: "false"

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -16,7 +16,8 @@ jobs:
         uses: renovatebot/github-action@v41.0.7
         with:
           configurationFile: .github/renovate.json
-          token: ${{ secrets.KROXYLICIOUS_GITHUB_READWRITE_TOKEN }}
+          token: ${{ secrets.KROXYLICIOUS_GITHUB_READWRITE_TOKEN || secrets.GITHUB_TOKEN}}
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_ONBOARDING: "false"
+          LOG_LEVEL: debug

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationIT.java
@@ -65,7 +65,8 @@ import static org.assertj.core.api.InstanceOfAssertFactories.DOUBLE;
 @EnabledIf(value = "isDockerAvailable", disabledReason = "docker unavailable")
 class OauthBearerValidationIT {
 
-    private static final DockerImageName DOCKER_IMAGE_NAME = DockerImageName.parse("ghcr.io/navikt/mock-oauth2-server").withTag("2.1.8");
+    private static final DockerImageName DOCKER_IMAGE_NAME = DockerImageName.parse("ghcr.io/navikt/mock-oauth2-server:2.1.8");
+
     private static final int OAUTH_SERVER_PORT = 28089;
     private static final String JWKS_ENDPOINT_URL = "http://localhost:" + OAUTH_SERVER_PORT + "/default/jwks";
     private static final URI OAUTH_ENDPOINT_URL = URI.create(JWKS_ENDPOINT_URL).resolve("/");

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/validation/JsonSchemaRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/validation/JsonSchemaRecordValidationIT.java
@@ -107,8 +107,7 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
     @BeforeAll
     public static void init() throws IOException {
         // An Apicurio Registry instance is required for this test to work, so we start one using a Generic Container
-        DockerImageName dockerImageName = DockerImageName.parse("quay.io/apicurio/apicurio-registry-mem")
-                .withTag("2.6.6.Final");
+        DockerImageName dockerImageName = DockerImageName.parse("quay.io/apicurio/apicurio-registry-mem:2.6.6.Final");
 
         Consumer<CreateContainerCmd> cmd = e -> e.withPortBindings(
                 new PortBinding(Ports.Binding.bindPort(APICURIO_REGISTRY_PORT), new ExposedPort(APICURIO_REGISTRY_PORT)));

--- a/performance-tests/docker-compose.yaml
+++ b/performance-tests/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
     networks:
       - perf_network
   vault:
-    image: ${VAULT_IMAGE:-docker.io/hashicorp/vault:1.15}
+    image: ${VAULT_IMAGE:-hashicorp/vault:1.15}
     hostname: vault
     container_name: vault
     ports:


### PR DESCRIPTION
* fallback to secrets.GITHUB_TOKEN so it'll work from a fork when run by the developer.
* extract `depName` from pattern to reduce the size of the config file.
* include a few extra container image deps.
* override ignoreList so that we consider /test/ files.

